### PR TITLE
Minimum working connection settings

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,3 @@ services:
     image: mongo:latest
     ports:
       - 37017:27017
-    environment:
-      MONGO_INITDB_ROOT_USERNAME: mongo_user
-      MONGO_INITDB_ROOT_PASSWORD: mongo_password

--- a/pydantic_odm/db.py
+++ b/pydantic_odm/db.py
@@ -55,9 +55,15 @@ class MongoDBManager:
         for alias, configuration in cls.settings.items():
             # Leave all parameters, exccept "NAME", empty, to
             # let connect with default system setting
-            params = ('USERNAME', 'PASSWORD', 'HOST', 'PORT')
-            if not any(configuration.get(n) for n in params):
+            username = configuration.get('USERNAME')
+            password = configuration.get('PASSWORD')
+            host = configuration.get('HOST')
+            port = configuration.get('PORT')
+            if not any((username, password, host, port)):
                 client = motor_asyncio.AsyncIOMotorClient()
+            # The HOST parameter is an Unix domain socket path
+            elif isinstance(host, str) and host.startswith('/'):
+                client = motor_asyncio.AsyncIOMotorClient(host)
             else:
                 client = motor_asyncio.AsyncIOMotorClient(
                     username=configuration.get('USERNAME'),

--- a/pydantic_odm/db.py
+++ b/pydantic_odm/db.py
@@ -11,29 +11,75 @@ class MongoDBManager:
     Singleton class for create main interface for working on many Mongo
     database connections from one place.
 
-    Usage:
+    Setting signature::
+        {
+            'connection_alias': {
+                'SETTING_NAME': 'SETTINGS_VALUE'
+            }
+        }
+
+    Very minimal connection configuration (Not recomended)::
+
+        'minimal': {}
+
+    .. note:: connection to 'minimal' Mongo database on mongodb://localhost:27017
+
+    Minimal connection configuration::
+
+        'minimal': {
+            'NAME': 'mongo-db-name'
+        }
+
+    Full connection configuration::
+
+        'full_configuration': {
+            'NAME': 'mongo-db-name',
+            'HOST': 'mongodb://localhost',
+            'PORT': 27017,
+            'USERNAME': 'mongo_user',
+            'PASSWORD': 'mongo_password',
+            'AUTHENTICATION_SOURCE': 'admin',
+            'AUTH-MECHANISM': 'SCRAM-SHA-256'
+        }
+
+    Connection params description:
+        - `NAME`: (str) Mongo database name for connection. If not setup - using configuration alias.
+        - `HOST`: (str) Mongo hostname. Configured by default as in PyMongo (`localhost`).
+        - `PORT`: (int) Mongo port. Configured by default as in PyMongo (27017).
+        - `USERNAME`: (str) Mongo administration username. Default - empty.
+        - `PASSWORD`: (str) Mongo administration password. Default - empty.
+        - `AUTHENTICATION_SOURCE`: (str) Mongo database name for authentication
+           source. Configured by default as in PyMongo ('admin')
+        - `AUTH-MECHANISM`: (str) Mongo authentication mechanism. If not setup -
+          PyMongo automatically selects a mechanism depending on the version of
+          MongoDB (See https://api.mongodb.com/python/current/examples/authentication.html#default-authentication-mechanism)
+
+
+    Usage::
+
     On startup application execute initial connect.
 
-    def startup():
-        MongoDBManager.initial_connections({
-            'default': {
-                'NAME': 'test_mongo',
-                'HOST': 'mongodb://localhost',
-                'PORT': 37017,
-                'USERNAME': 'mongo_user',
-                'PASSWORD': 'mongo_password',
-                'AUTHENTICATION_SOURCE': 'admin',
-            },
-            'default_linux': {
-                'NAME': 'test_mongo'
-            }
-        })
+        def startup():
+            MongoDBManager.initial_connections({
+                'default': {
+                    'NAME': 'mongo-db-name',
+                    'HOST': 'mongodb://localhost',
+                    'PORT': 27017,
+                    'USERNAME': 'mongo_user',
+                    'PASSWORD': 'mongo_password',
+                    'AUTHENTICATION_SOURCE': 'admin',
+                    'AUTH-MECHANISM': 'SCRAM-SHA-256'
+                },
+                'minimal_configured_db': {
+                    'NAME': 'mongo-db-name'
+                }
+            })
 
     Get collection in all place in your code:
     from pydantic_odm.db import MongoDBManager
     ...
     any_collections = MongoDBManager.default.any_collections
-    """
+    """  # noqa: E501
 
     settings: Dict[str, Dict[str, Any]] = {}
     connections: Dict[str, motor_asyncio.AsyncIOMotorClient] = {}
@@ -53,26 +99,17 @@ class MongoDBManager:
         cls.settings = settings
 
         for alias, configuration in cls.settings.items():
-            # Leave all parameters, exccept "NAME", empty, to
-            # let connect with default system setting
-            username = configuration.get('USERNAME')
-            password = configuration.get('PASSWORD')
-            host = configuration.get('HOST')
-            port = configuration.get('PORT')
-            if not any((username, password, host, port)):
-                client = motor_asyncio.AsyncIOMotorClient()
-            # The HOST parameter is an Unix domain socket path
-            elif isinstance(host, str) and host.startswith('/'):
-                client = motor_asyncio.AsyncIOMotorClient(host)
-            else:
-                client = motor_asyncio.AsyncIOMotorClient(
-                    username=configuration.get('USERNAME'),
-                    password=configuration.get('PASSWORD'),
-                    host=configuration.get('HOST', 'localhost'),
-                    port=configuration.get('PORT', 27017),
-                    authSource=configuration.get('AUTH_SOURCE', 'admin'),
-                    authMechanism=configuration.get('AUTH_MEC', 'SCRAM-SHA-256'),
-                )
+            connection_params = {
+                'username': configuration.get('USERNAME'),
+                'password': configuration.get('PASSWORD'),
+                'host': configuration.get('HOST'),
+                'port': configuration.get('PORT'),
+                'authSource': configuration.get('AUTH_SOURCE', ''),
+            }
+            auth_mech = configuration.get('AUTH_MECHANISM')
+            if auth_mech:
+                connection_params['authMechanism'] = auth_mech
+            client = motor_asyncio.AsyncIOMotorClient(**connection_params)
             db_name = configuration.get('NAME', alias)
             cls.connections[alias] = client
             db = client[db_name]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,9 +3,10 @@ import pytest
 
 from pydantic_odm.db import MongoDBManager
 
-from .db import DATABASE_SETTING
-
 pytestmark = pytest.mark.asyncio
+
+
+DATABASE_SETTING = {'default': {'NAME': 'test_mongo', 'PORT': 37017}}
 
 
 @pytest.fixture()

--- a/tests/db.py
+++ b/tests/db.py
@@ -5,19 +5,9 @@ import pytest
 
 from pydantic_odm import db
 
+from .conftest import DATABASE_SETTING
+
 pytestmark = pytest.mark.asyncio
-
-
-DATABASE_SETTING = {
-    'default': {
-        'NAME': 'test_mongo',
-        'HOST': 'mongodb://localhost',
-        'PORT': 37017,
-        'USERNAME': 'mongo_user',
-        'PASSWORD': 'mongo_password',
-        'AUTHENTICATION_SOURCE': 'admin',
-    }
-}
 
 
 class TestMongoDBManager:

--- a/tests/db.py
+++ b/tests/db.py
@@ -1,7 +1,9 @@
 """Tests for database connector module"""
+import importlib
+
 import pytest
 
-from pydantic_odm.db import MongoDBManager
+from pydantic_odm import db
 
 pytestmark = pytest.mark.asyncio
 
@@ -22,17 +24,27 @@ class TestMongoDBManager:
     async def test_create_instance(self):
         raise_msg = 'This is singleton object'
         with pytest.raises(TypeError, match=raise_msg):
-            MongoDBManager()
+            db.MongoDBManager()
 
     async def test_init_connections(self):
-        dbm = await MongoDBManager.init_connections(DATABASE_SETTING)
-        assert dbm == MongoDBManager
+        dbm = await db.MongoDBManager.init_connections(DATABASE_SETTING)
+        assert dbm == db.MongoDBManager
         assert len(dbm.connections) == 1
         assert dbm.connections['default']
         assert len(dbm.databases) == 1
         assert dbm.databases['default'].name == 'test_mongo'
 
+    async def test_init_connection_with_empty_conf(self):
+        importlib.reload(db)
+        dbm = await db.MongoDBManager.init_connections({'minimal': {}})
+        assert dbm == db.MongoDBManager
+        assert len(dbm.connections) == 1
+        assert dbm.connections['minimal']
+        assert len(dbm.databases) == 1
+        assert dbm.databases['minimal'].name == 'minimal'
+
     async def test_get_db_with_getattr(self):
-        dbm = await MongoDBManager.init_connections(DATABASE_SETTING)
-        db = dbm.databases['default']
-        assert dbm['default'] == db
+        importlib.reload(db)
+        dbm = await db.MongoDBManager.init_connections(DATABASE_SETTING)
+        database = dbm.databases['default']
+        assert dbm['default'] == database

--- a/tests/mixin.py
+++ b/tests/mixin.py
@@ -62,7 +62,7 @@ class TestBaseDBMixin(mixins.BaseDBMixin):
         nested_model._doc = {
             'username': 'new_test_user',
             'comments': [
-                {'title': 'Newest title from db', 'timestamp': example_model.timestamp,}
+                {'title': 'Newest title from db', 'timestamp': example_model.timestamp}
             ],
         }
         nested_model._update_model_from__doc()


### PR DESCRIPTION
On Linux, especially in development, authentication for local MongoDB is not needed to set. It help save effort of keeping secret info around. This PR allows to connect to a local MongoDB server with minimum settings.