### PR TITLE
Renamed `_id` property in `PydanticDBMixin` and updated mixin classes

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,8 @@
+## 0.2 (unreleased)
+
+* Implemented `id` public property for `PydanticDBMixin`. Updated *db mixins* and their tests. PR #17 by @i8enn
+
+
 ## 0.1.6 (20.01.2020)
 
 * Fix arguments type in `update_many` method from `PydanticDBMixin`. PR #16 by @i8enn

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,9 @@
 isort = isort -rc pydantic_odm tests
 black = black -S -l 88 --target-version py37 pydantic_odm tests
 
+# Makefile target args
+args = $(filter-out $@,$(MAKECMDGOALS))
+
 .PHONY: install
 install:
 	pip install -U pipenv
@@ -40,6 +43,10 @@ mypy:
 .PHONY: test
 test:
 	pytest --cov=pydantic_odm
+
+.PHONY: testwatch
+testwatch: testwatch
+	pytest --cov=pydantic_odm -fsvvl --ff --color=yes ${args}
 
 .PHONY: testcov
 testcov: test

--- a/Pipfile
+++ b/Pipfile
@@ -18,6 +18,7 @@ pycodestyle = "==2.5.0"
 pyflakes = "==2.1.1"
 pytest-cov = "==2.8.1"
 pytest-mock = "==1.12.1"
+devtools = "*"
 
 [packages]
 motor = '>=2.0.0'

--- a/pydantic_odm/mixins.py
+++ b/pydantic_odm/mixins.py
@@ -23,37 +23,48 @@ if TYPE_CHECKING:
 class BaseDBMixin(BaseModel, abc.ABC):
     """Base class for Pydantic mixins"""
 
-    _doc: Dict = None
+    # Read-only (for public) field for store MongoDB id
+    _id: ObjectIdStr = None
+    _doc: Dict = {}
+
+    class Config:
+        allow_population_by_field_name = True
+        schema_extra = {'id': 'str'}
+
+    def __setattr__(self, key, value):
+        if key not in ['_doc', '_id']:
+            return super(BaseDBMixin, self).__setattr__(key, value)
+        self.__dict__[key] = value
+        return value
+
+    @property
+    def id(self) -> ObjectIdStr:
+        return self._id
 
     def _update_model_from__doc(self) -> BaseDBMixin:
         """
         Update model fields from _doc dictionary
         (projection of a document from DB)
         """
-        for name, field in self.__fields__.items():
-            value = self._doc.get(name)
-            if issubclass(field.type_, BaseModel) and isinstance(value, dict):
-                value = field.type_.parse_obj(value)
-            setattr(self, name, value)
-        return self
+        new_obj = self.parse_obj(self._doc)
+        new_obj._id = self._doc.get('_id')
+        for k, v in new_obj.__dict__.items():
+            self.__dict__[k] = v
+        return new_obj
 
-
-class DBPydanticMixin(BaseDBMixin):
-    """Help class for communicate of Pydantic model and MongoDB"""
-
-    _id: ObjectIdStr = None
-
-    class Config:
-        # DB
-        collection: str = None
-        database: str = None
-        json_encoders = {ObjectId: lambda v: ObjectIdStr(v)}
-
-    def __setattr__(self, key, value):
-        if key not in ['_id', '_doc']:
-            return super(DBPydanticMixin, self).__setattr__(key, value)
-        self.__dict__[key] = value
-        return value
+    @classmethod
+    def _convert_id_in_mongo_query(cls, query: Dict) -> Dict:
+        _query = {}
+        for k, v in query.items():
+            if k == 'id':
+                _query['_id'] = v
+            elif isinstance(v, dict):
+                _query[k] = cls._convert_id_in_mongo_query(v)
+            elif isinstance(v, (list, tuple)):
+                _query[k] = [cls._convert_id_in_mongo_query(i) for i in v]
+            else:
+                _query[k] = v
+        return _query
 
     def dict(
         self,
@@ -66,7 +77,35 @@ class DBPydanticMixin(BaseDBMixin):
         exclude_defaults: bool = False,
         exclude_none: bool = False,
     ) -> DictStrAny:
-        return super(DBPydanticMixin, self).dict(exclude={'_doc'})
+        if not exclude:
+            exclude = {'_doc', '_id'}
+        else:
+            exclude.update({'_doc', '_id'})  # noqa
+
+        d = super(BaseDBMixin, self).dict(
+            include=include,
+            exclude=exclude,
+            by_alias=by_alias,
+            exclude_unset=exclude_unset,
+            exclude_defaults=exclude_defaults,
+            exclude_none=exclude_none,
+        )
+
+        # Simulating field alias behavior
+        if (not self.id and (exclude_none or exclude_defaults)) or 'id' in exclude:
+            return d
+        d['id'] = self.id
+        return d
+
+
+class DBPydanticMixin(BaseDBMixin):
+    """Help class for communicate of Pydantic model and MongoDB"""
+
+    class Config:
+        # DB
+        collection: str = None
+        database: str = None
+        json_encoders = {ObjectId: lambda v: ObjectIdStr(v)}
 
     @classmethod
     async def get_collection(cls) -> Collection:
@@ -97,6 +136,7 @@ class DBPydanticMixin(BaseDBMixin):
         """Return count by query or all documents in collection"""
         if not query:
             query = {}
+        query = cls._convert_id_in_mongo_query(query)
         collection = await cls.get_collection()
         return await collection.count_documents(query)
 
@@ -104,6 +144,7 @@ class DBPydanticMixin(BaseDBMixin):
     async def find_one(cls, query: Dict) -> DBPydanticMixin:
         """Find and return model from db by pymongo query"""
         collection = await cls.get_collection()
+        query = cls._convert_id_in_mongo_query(query)
         result = await collection.find_one(query)
         if result:
             model = cls.parse_obj(result)
@@ -121,6 +162,7 @@ class DBPydanticMixin(BaseDBMixin):
         or query cursor
         """
         collection = await cls.get_collection()
+        query = cls._convert_id_in_mongo_query(query)
         cursor = collection.find(query)
         if return_cursor:
             return cursor
@@ -128,7 +170,7 @@ class DBPydanticMixin(BaseDBMixin):
         documents = []
         async for _doc in cursor:
             document = cls.parse_obj(_doc)
-            document._id = _doc['_id']
+            document._id = _doc.get('_id')
             document._doc = _doc
             documents.append(document)
         return documents
@@ -144,6 +186,7 @@ class DBPydanticMixin(BaseDBMixin):
         Find and update documents by query
         """
         collection = await cls.get_collection()
+        query = cls._convert_id_in_mongo_query(query)
         await collection.update_many(query, fields)
         return await cls.find_many(query, return_cursor)
 
@@ -174,6 +217,7 @@ class DBPydanticMixin(BaseDBMixin):
         if not self._id:
             raise ValueError('Not found _id in current model instance')
         _doc = await collection.find_one({'_id': self._id})
+        _doc.pop('_id')
         if _doc:
             self._doc = _doc
             self._update_model_from__doc()
@@ -205,10 +249,10 @@ class DBPydanticMixin(BaseDBMixin):
             instance = await collection.insert_one(self.dict())
             if instance:
                 self._id = instance.inserted_id
-                self._doc = {'_id': self._id, **self.dict()}
+                self._doc = {'_id': instance.inserted_id, **self.dict(exclude={'id'})}
         else:
             updated = {}
-            for field, value in self.dict().items():
+            for field, value in self.dict(exclude={'id'}).items():
                 if self._doc.get(field) != value:
                     updated[field] = value
             if updated:

--- a/tests/mixin.py
+++ b/tests/mixin.py
@@ -1,6 +1,7 @@
 """Tests for pydantic models mixins"""
+import json
 import re
-from datetime import datetime
+from datetime import datetime, timedelta
 from typing import List, Optional
 
 import pytest
@@ -14,330 +15,424 @@ from pydantic_odm import mixins
 pytestmark = pytest.mark.asyncio
 
 
-class ExampleModel(mixins.DBPydanticMixin):
-    title: str
+class User(mixins.DBPydanticMixin):
+    """Example user model"""
+
+    username: str
     created: datetime
-    age: int
+    age: Optional[int]
 
     class Config:
         database = 'default'
-        collection = 'test_collection'
+        collection = 'test_user'
 
 
-class ExampleEmbeddedModel(mixins.BaseDBMixin):
-    title: str
-    timestamp: datetime
+class Comment(mixins.BaseDBMixin):
+    """Example comments model (for embed to post)"""
+
+    body: str
+    created: datetime
     parent: Optional[List[mixins.BaseDBMixin]] = list()
 
 
-class ExampleNestedModel(mixins.DBPydanticMixin):
-    username: str
-    info: ExampleModel = None
-    comments: Optional[List[ExampleEmbeddedModel]]
+class Post(mixins.DBPydanticMixin):
+    """Example post model"""
+
+    title: str
+    body: str
+    author: User
+    comments: Optional[List[Comment]]
 
     class Config:
         database = 'default'
-        collection = 'test_example_nested'
+        collection = 'test_post'
 
 
-class ExampleModelInUpdate(BaseModel):
+class UserSerializer(BaseModel):
     """Scheme (serializer) for update example model"""
 
-    title: Optional[str]
+    username: Optional[str]
     created: Optional[datetime]
     age: Optional[int]
 
 
-class TestBaseDBMixin(mixins.BaseDBMixin):
+class TestBaseDBMixin:
     async def test__update_model_from__doc(self):
-        example_model = ExampleEmbeddedModel(
-            title='Test comment #1', timestamp=datetime.now()
-        )
-        example_model._doc = {'title': 'Test comment #1'}
-        example_model._update_model_from__doc()
-        assert example_model._doc == example_model.dict()
+        # Simple model
+        user = User(username='test_user', created=datetime.now(), age=10)
+        user._doc = {
+            '_id': ObjectId(),
+            'username': 'new_test_user',
+            'created': user.created + timedelta(days=1),
+        }
+        user._update_model_from__doc()
+        assert user.id == user._doc.get('_id')
+        assert user.username == user._doc.get('username')
+        assert user.created == user._doc.get('created')
+        assert user.age == user._doc.get('age')
 
         # Nested model
-        nested_model = ExampleNestedModel(username='test_user')
-        nested_model._doc = {
-            'username': 'new_test_user',
+        post = Post(title='test_title', body='test_body', author=user)
+        post._doc = {
+            '_id': ObjectId(),
+            'title': 'new_test_title',
+            'body': 'new_test_body',
+            'author': user.dict(exclude_defaults=True),
             'comments': [
-                {'title': 'Newest title from db', 'timestamp': example_model.timestamp}
+                {
+                    '_id': ObjectId(),
+                    'body': 'Newest title from db',
+                    'created': datetime.now(),
+                },
+                {
+                    '_id': ObjectId(),
+                    'body': 'Newest title from db',
+                    'created': datetime.now(),
+                },
             ],
         }
-        nested_model._update_model_from__doc()
-        assert nested_model._doc == nested_model.dict()
-        assert nested_model.comments[0] == example_model
+        post._update_model_from__doc()
+        assert post.id == post._doc.get('_id')
+        assert post.title == post._doc.get('title')
+        assert post.body == post._doc.get('body')
+        author_from_doc = post._doc.get('author')
+        assert post.author.id == author_from_doc.get('_id')
+        assert post.author.username == author_from_doc.get('username')
+        assert post.author.created == author_from_doc.get('created')
+        assert post.author.age == author_from_doc.get('age')
+        # First comment
+        comment_from_doc = post._doc.get('comments', [])[0]
+        assert isinstance(post.comments[0], Comment)
+        assert post.comments[0].body == comment_from_doc.get('body')
+        assert post.comments[0].created == comment_from_doc.get('created')
+        # Second comment
+        comment_from_doc = post._doc.get('comments', [])[1]
+        assert isinstance(post.comments[1], Comment)
+        assert post.comments[1].body == comment_from_doc.get('body')
+        assert post.comments[1].created == comment_from_doc.get('created')
+
+    async def test_exclude__doc_from_dict(self):
+        user = User(username='test', created=datetime.now(), age=10)
+        user._doc = {
+            'username': user.username,
+            'created': user.created,
+            'age': user.age,
+        }
+        user_as_dict = user.dict(exclude_defaults=True)
+        assert '_doc' not in user_as_dict.keys()
+        assert user_as_dict == user._doc
+
+    async def test_convert__id_field_in_dict(self):
+        user = User(username='test', created=datetime.now(), age=10)
+        user._id = ObjectId()
+        assert user.id
+        user_as_dict = user.dict(exclude_unset=True)
+        assert user_as_dict.get('id') == user.id
+
+    async def test_schema(self):
+        user = User(username='test', created=datetime.now(), age=10)
+        user._id = ObjectId()
+        user._doc = user.dict()
+        assert user.id
+        assert user._doc
+        schema = json.loads(user.schema_json())
+        assert '_doc' not in schema.keys()
+        assert schema.get('id') == 'str'
+
+    async def test__convert_id_in_mongo_query(self):
+        query = {
+            'id': ObjectId(),
+            'title': 'test',
+            'author': {'id': ObjectId(), 'username': 'test_author'},
+            'comments': [
+                {'id': ObjectId(), 'username': 'test_user_1', 'body': 'test_comment_1'},
+                {'id': ObjectId(), 'username': 'test_user_2', 'body': 'test_comment_2'},
+            ],
+        }
+        converted_query = Post._convert_id_in_mongo_query(query)
+        assert isinstance(converted_query, dict)
+        assert converted_query.get('_id')
+        assert not converted_query.get('id')
+        author = converted_query.get('author', {})
+        assert author.get('_id')
+        assert not author.get('id')
+        comment_1 = converted_query.get('comments', [])[0]
+        assert comment_1.get('_id')
+        assert not comment_1.get('id')
+        comment_2 = converted_query.get('comments', [])[1]
+        assert comment_2.get('_id')
+        assert not comment_2.get('id')
 
 
 class TestDBPydanticMixin:
-    async def test_exclude__doc_from_dict(self):
-        example_model = ExampleModel(title='test', created=datetime.now(), age=10)
-        example_model._doc = {
-            'title': example_model.title,
-            'created': example_model.created,
-            'age': example_model.age,
-        }
-        example_model_as_dict = example_model.dict()
-        assert '_doc' not in example_model_as_dict.keys()
-        assert example_model_as_dict == example_model._doc
-
     async def test_jsonable_model(self, init_test_db):
-        example_model = ExampleModel(title='test', created=datetime.now(), age=10)
-        example_model._id = ObjectId()
-        assert isinstance(example_model._id, ObjectId)
-        assert example_model.json()
+        user = User(username='test', created=datetime.now(), age=10)
+        user._id = ObjectId()
+        assert isinstance(user._id, ObjectId)
+        assert user.json()
 
     async def test_get_collection(self, init_test_db, monkeypatch):
-        col = await ExampleModel.get_collection()
+        col = await User.get_collection()
         assert isinstance(col, motor_asyncio.AsyncIOMotorCollection)
 
     async def test_get_collection_in_unconfigured_config(
         self, init_test_db, monkeypatch
     ):
-        monkeypatch.delattr(ExampleModel.Config, 'database')
-        monkeypatch.delattr(ExampleModel.Config, 'collection')
+        monkeypatch.delattr(User.Config, 'database')
+        monkeypatch.delattr(User.Config, 'collection')
         raise_msg = 'Collection or db_name is not configured in Config class'
         with pytest.raises(ValueError, match=raise_msg):
-            _ = await ExampleModel.get_collection()
+            _ = await User.get_collection()
 
         monkeypatch.undo()
 
     async def test_get_collection_with_unconfigured_db(self, init_test_db, monkeypatch):
         db_name = 'unconfigured'
-        monkeypatch.setattr(ExampleModel.Config, 'database', db_name)
+        monkeypatch.setattr(User.Config, 'database', db_name)
         raise_msg = '"%s" is not found in MongoDBManager.database' % db_name
         with pytest.raises(ValueError, match=raise_msg):
-            _ = await ExampleModel.get_collection()
+            _ = await User.get_collection()
         monkeypatch.undo()
 
     async def test_save_model_with_new_doc(self, init_test_db):
-        model_data = {'title': 'Test title', 'created': datetime.now(), 'age': 10}
-        exmpl_model = ExampleModel(**model_data)
-        assert exmpl_model
-        assert exmpl_model.title == model_data['title']
-        assert exmpl_model.created == model_data['created']
-        assert exmpl_model.age == model_data['age']
+        model_data = {'username': 'test', 'created': datetime.now(), 'age': 10}
+        user = User(**model_data)
+        assert user
+        assert user.username == model_data['username']
+        assert user.created == model_data['created']
+        assert user.age == model_data['age']
 
-        assert not exmpl_model._id
-        assert not exmpl_model._doc
-        await exmpl_model.save()
-        assert exmpl_model
-        doc = exmpl_model._doc
-        assert doc.get('_id') == exmpl_model._id
-        assert doc.get('title') == exmpl_model.title
-        assert doc.get('created') == exmpl_model.created
-        assert doc.get('age') == exmpl_model.age
+        assert not user._id
+        assert not user._doc
+        await user.save()
+        assert user
+        doc = user._doc
+        assert 'id' not in doc.keys()
+        assert doc.get('username') == user.username
+        assert doc.get('created') == user.created
+        assert doc.get('age') == user.age
 
-    async def test_save_model_with_created_doc(self, init_test_db):
-        model_data = {'title': 'Test title', 'created': datetime.now(), 'age': 10}
-        exmpl_model = ExampleModel(**model_data)
-        await exmpl_model.save()
-        assert exmpl_model
-        id = exmpl_model._id
+    async def test_save_model_with_exists_doc(self, init_test_db):
+        model_data = {'username': 'test', 'created': datetime.now(), 'age': 10}
+        user = User(**model_data)
+        await user.save()
+        assert user
+        old_id = user._id
 
-        new_title = 'New test title'
-        exmpl_model.title = new_title
-        await exmpl_model.save()
-        assert exmpl_model.title == new_title
-        assert exmpl_model._doc.get('title') == new_title
-        assert exmpl_model._doc.get('_id') == exmpl_model._id
-        assert exmpl_model._id == id
+        new_username = 'new_test'
+        user.username = new_username
+        await user.save()
+        assert user.username == new_username
+        assert user._doc.get('username') == new_username
+        assert 'id' not in user._doc.keys()
+        assert user._doc.get('_id') == old_id
+        assert old_id == user.id
 
     async def test_save_nested_model(self, init_test_db):
-        model_data = {'title': 'Test title', 'created': datetime.now(), 'age': 10}
-        exmpl_model = ExampleModel(**model_data)
-        assert exmpl_model
+        model_data = {'username': 'test', 'created': datetime.now(), 'age': 10}
+        user = User(**model_data)
+        assert user
 
-        nested_model = ExampleNestedModel(username='test', info=exmpl_model)
-        assert nested_model
-        assert nested_model.info == exmpl_model
+        post = Post(title='test', body='test_body', author=user)
+        assert post
+        assert post.author == user
 
-        await nested_model.save()
+        await post.save()
 
-        doc = nested_model._doc
-        assert doc.get('username') == 'test'
-        assert doc.get('info') == model_data
+        doc = post._doc
+        assert doc.get('title') == post.title
+        assert doc.get('body') == post.body
+        author_from_doc = doc.get('author', {})
+        assert author_from_doc.get('username') == post.author.username
+        assert author_from_doc.get('created') == post.author.created
+        assert author_from_doc.get('age') == post.author.age
 
-    async def test_create(self, init_test_db):
-        model_data = {'title': 'Test title', 'created': datetime.now(), 'age': 10}
-        # With dict
-        model = await ExampleModel.create(model_data)
+    @pytest.mark.parametrize(
+        'model_data',
+        [
+            {'username': 'test', 'created': datetime.now(), 'age': 10},
+            UserSerializer.parse_obj(
+                {'username': 'test', 'created': datetime.now(), 'age': 10}
+            ),
+        ],
+        ids=['dict', 'pydantic_model'],
+    )
+    async def test_create(self, init_test_db, model_data):
+        model = await User.create(model_data)
+        if isinstance(model_data, BaseModel):
+            model_data = model_data.dict()
         assert model
         assert model._id
-        assert model._doc.keys() == model.dict().keys()
-        assert model.title == model_data['title']
-        assert model.created == model_data['created']
-        assert model.age == model_data['age']
-
-        # With pydantic model
-        model = await ExampleModel.create(ExampleModelInUpdate.parse_obj(model_data))
-        assert model
-        assert model._id
-        assert model._doc.keys() == model.dict().keys()
-        assert model.title == model_data['title']
+        assert 'id' not in model._doc.keys()
+        assert model._doc.get('_id') == model._id
+        assert model.username == model_data['username']
         assert model.created == model_data['created']
         assert model.age == model_data['age']
 
     async def test_count(self, init_test_db):
         models = [
-            ExampleModel(title='Model #%d' % i, created=datetime.now(), age=i)
+            User(username='test_user_#%d' % i, created=datetime.now(), age=i)
             for i in range(1, 6)
         ]
-        await ExampleModel.bulk_create(models[0:3])
-        assert await ExampleModel.count() == 3
-        await ExampleModel.bulk_create(models[3::])
-        assert await ExampleModel.count() == 5
+        await User.bulk_create(models[0:3])
+        assert await User.count() == 3
+        await User.bulk_create(models[3::])
+        assert await User.count() == 5
 
     async def test_find_one(self, init_test_db):
         model_data = {
-            'title': 'Test title',
+            'username': 'test',
             'created': datetime.utcnow().isoformat(),
             'age': 10,
         }
-        exmpl_model = ExampleModel(**model_data)
-        await exmpl_model.save()
+        user = User(**model_data)
+        await user.save()
 
-        result = await ExampleModel.find_one({'_id': exmpl_model._id})
+        result = await User.find_one({'id': user.id})
         assert result
 
-        assert result._id
-        assert result._doc.keys() == exmpl_model.dict().keys()
-        assert exmpl_model.title == result.title
-        assert exmpl_model.created.date() == result.created.date()
-        assert exmpl_model.age == result.age
+        assert result.id == user.id
+        assert user.username == result.username
+        assert user.created.date() == result.created.date()
+        assert user.age == result.age
 
     async def test_find_one_with_empty_result(self, init_test_db):
-        result = await ExampleModel.find_one({'_id': 'undefined_id'})
+        result = await User.find_one({'_id': 'undefined_id'})
         assert not result
 
-    async def test_bulk_create(self, init_test_db):
-        models = [
-            ExampleModel(title='Model #%d' % i, created=datetime.now(), age=i)
-            for i in range(1, 5)
-        ]
-        # With model
-        saved_models = await ExampleModel.bulk_create(models)
+    @pytest.mark.parametrize(
+        'models',
+        [
+            [
+                {'username': 'test_user_%d' % i, 'created': datetime.now(), 'age': i}
+                for i in range(1, 5)
+            ],
+            [
+                User(username='test_user_%d' % i, created=datetime.now(), age=i)
+                for i in range(1, 5)
+            ],
+        ],
+        ids=['dict', 'pydantic_model'],
+    )
+    async def test_bulk_create(self, init_test_db, models):
+        saved_models = await User.bulk_create(models)
         assert saved_models
         for model in saved_models:
-            assert isinstance(model, ExampleModel)
-            assert model._id
-            assert model._doc == model.dict()
-        # With dict
-        saved_models = await ExampleModel.bulk_create([d.dict() for d in models])
-        assert saved_models
-        for model in saved_models:
-            assert isinstance(model, ExampleModel)
-            assert model._id
-            assert model._doc == model.dict()
+            assert isinstance(model, User)
+            assert model._id == model._doc.get('_id')
+            assert model.username == model._doc.get('username')
+            assert model.created == model._doc.get('created')
+            assert model.age == model._doc.get('age')
 
     async def test_find_many(self, init_test_db):
         models = [
-            ExampleModel(title='Model #%d' % i, created=datetime.now(), age=i)
+            User(username='test_user_%d' % i, created=datetime.now(), age=i)
             for i in range(1, 5)
         ]
-        await ExampleModel.bulk_create(models)
+        await User.bulk_create(models)
 
-        query = {'title': {'$regex': re.compile('[0-3]', re.IGNORECASE)}}
-        result = await ExampleModel.find_many(query)
+        query = {'username': {'$regex': re.compile('[0-3]', re.IGNORECASE)}}
+        result = await User.find_many(query)
         assert result
         assert len(result) == 3
 
         for document in result:
-            assert isinstance(document, ExampleModel)
-            assert document._id
-            assert document._doc == document.dict()
+            assert isinstance(document, User)
+            assert document.id == document._doc.get('_id')
+            assert document.username == document._doc.get('username')
+            assert document.created == document._doc.get('created')
+            assert document.age == document._doc.get('age')
 
     async def test_update_many(self, init_test_db):
         models = [
-            ExampleModel(title='Model #%d' % i, created=datetime.now(), age=i)
+            User(username='test_user_%d' % i, created=datetime.now(), age=i)
             for i in range(1, 5)
         ]
-        await ExampleModel.bulk_create(models)
+        await User.bulk_create(models)
 
         # Update documents whose age more than 1 and less than 4
         query = {'age': {'$gt': 1, '$lte': 3}}
-        fields = {'$set': {'title': 'New Model Title!'}}
-        updated_documents = await ExampleModel.update_many(query, fields)
+        fields = {'$set': {'username': 'new_user_name'}}
+        updated_documents = await User.update_many(query, fields)
         for doc in updated_documents:
             assert 1 < doc.age <= 3
-            assert doc.title == 'New Model Title!'
+            assert doc.username == 'new_user_name'
 
     async def test_update(self, init_test_db):
         model_data = {
-            'title': 'Test title',
+            'username': 'test_username',
             'created': datetime.utcnow().isoformat(),
             'age': 10,
         }
-        example_model = ExampleModel(**model_data)
-        await example_model.save()
-        assert example_model
+        user = User(**model_data)
+        await user.save()
+        assert user
 
-        update_data = {'title': 'New Test Title', 'age': None}
-        updated_model = await example_model.update(update_data)
-        assert updated_model.title == update_data['title']
+        update_data = {'username': 'new_username', 'age': None}
+        updated_model = await user.update(update_data)
+        assert updated_model.username == update_data['username']
         assert updated_model.age == update_data['age']
-        assert updated_model.created == example_model.created
+        assert updated_model.created == user.created
 
-        update_data = {'title': 'Title from Pydantic'}
-        pydantic_updated_data = ExampleModelInUpdate.parse_obj(update_data)
+        update_data = {'username': 'username_from_pydantic'}
+        pydantic_updated_data = UserSerializer.parse_obj(update_data)
         old_updated_model = updated_model
-        updated_model = await example_model.update(pydantic_updated_data)
-        assert updated_model.title == update_data['title']
+        updated_model = await user.update(pydantic_updated_data)
+        assert updated_model.username == update_data['username']
         assert updated_model.age == old_updated_model.age
         assert updated_model.created == old_updated_model.created
 
         # Without model._id
-        example_model._id = None
+        user._id = None
         raise_msg = 'Not found _id in current model instance'
         with pytest.raises(ValueError, match=raise_msg):
-            await example_model.reload()
+            await user.reload()
 
     async def test_reload_model(self, init_test_db):
         model_data = {
-            'title': 'Test title',
+            'username': 'test_user',
             'created': datetime.utcnow().isoformat(),
             'age': 10,
         }
-        example_model = ExampleModel(**model_data)
-        await example_model.save()
+        user = User(**model_data)
+        await user.save()
 
         # Change document in db without model
-        collection = await example_model.get_collection()
-        new_example_model = await collection.find_one_and_update(
-            {'_id': example_model._id},
-            {'$set': {'title': 'New test title'}},
+        collection = await user.get_collection()
+        new_user = await collection.find_one_and_update(
+            {'_id': user._id},
+            {'$set': {'username': 'new_username'}},
             return_document=ReturnDocument.AFTER,
         )
-        assert new_example_model
-        assert example_model.title != new_example_model['title']
+        assert new_user
+        assert user.username != new_user['username']
 
-        reloaded_model = await example_model.reload()
-        assert reloaded_model == example_model
-        assert reloaded_model.title == new_example_model['title']
+        reloaded_model = await user.reload()
+        assert reloaded_model == user
+        assert reloaded_model.username == new_user['username']
 
         # Without model._id
-        example_model._id = None
+        user._id = None
         raise_msg = 'Not found _id in current model instance'
         with pytest.raises(ValueError, match=raise_msg):
-            await example_model.reload()
+            await user.reload()
 
     async def test_delete(self, init_test_db):
         model_data = {
-            'title': 'Test title',
+            'username': 'test_user',
             'created': datetime.utcnow().isoformat(),
             'age': 10,
         }
-        example_model = ExampleModel(**model_data)
-        await example_model.save()
+        user = User(**model_data)
+        await user.save()
 
-        await example_model.delete()
+        await user.delete()
 
-        assert not example_model._doc
-        assert not await example_model.find_one({'_id': example_model._id})
+        assert not user._doc
+        assert not await user.find_one({'id': user._id})
 
         # Without model._id
-        example_model._id = None
+        user._id = None
         raise_msg = 'Not found _id in current model instance'
         with pytest.raises(ValueError, match=raise_msg):
-            await example_model.reload()
+            await user.reload()


### PR DESCRIPTION
* Moved `_id` model property from `PydanticDBMixin` to `BaseDBMixin`
* Implemented public `id` property returns `_id` property value (#10)
* Moved `dict` and `__setattr__` methods from `PydanticDBMixin` to `BaseDBMixin`
* Implemented replacing `_id` to `id` with encode model to `dict` (`BaseDBMixin.dict()`)
* Implemented excluding `_id` and `_doc` mixin system properties by default in model encoding.
* Implemented converting `id` to `_id` in MongoDB query (with only `PydanticDBMixin` methods)
* Cleanup tests for `mixin.py`
* Added `devtools` to dev dependencies
* Added command for run pytest with 'looponfail' mode to Makefile