### PR TITLE
Fix creating empty id field when creating new document

### DIFF
--- a/pydantic_odm/mixins.py
+++ b/pydantic_odm/mixins.py
@@ -263,7 +263,7 @@ class DBPydanticMixin(BaseDBMixin):
     async def save(self) -> DBPydanticMixin:
         collection = await self.get_collection()
         if not self.id:
-            data = self._encode_model_to_mongo()
+            data = self._encode_model_to_mongo(exclude={'id'})
             instance = await collection.insert_one(data)
             if instance:
                 self.id = instance.inserted_id


### PR DESCRIPTION
Fix #23 

`exclude={'id'}` was only added when updating a document, now I added to creating as well.

PS. maybe setting "exclude_none" to true can be another solution?