### PR TITLE
Feature: passing in optional parameters of AsyncIOMotorClient

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,8 +38,12 @@ check-dist:
 	python setup.py sdist
 	twine check dist/*
 
+.PHONY: start-mongo
+start-mongo:
+	docker-compose up -d
+
 .PHONY: test
-test:
+test: start-mongo
 	pytest --cov=pydantic_odm --cov-config=setup.cfg --no-cov-on-fail
 
 .PHONY: testwatch
@@ -76,3 +80,4 @@ clean:
 	rm -rf dist
 	python setup.py clean
 	rm -rf site
+	docker-compose down -v

--- a/Makefile
+++ b/Makefile
@@ -38,16 +38,20 @@ check-dist:
 	python setup.py sdist
 	twine check dist/*
 
-.PHONY: start-mongo
-start-mongo:
+.PHONY: up-services
+up-services:
 	docker-compose up -d
 
+.PHONY: down-services
+down-services:
+	docker-compose down -v
+
 .PHONY: test
-test: start-mongo
+test: up-services
 	pytest --cov=pydantic_odm --cov-config=setup.cfg --no-cov-on-fail
 
 .PHONY: testwatch
-testwatch: testwatch
+testwatch: up-services
 	pytest -fsvv --ff --color=yes ${args}
 
 .PHONY: testcov
@@ -64,7 +68,7 @@ testcov-report:
 all: testcov lint
 
 .PHONY: clean
-clean:
+clean: down-services
 	rm -rf `find . -name __pycache__`
 	rm -f `find . -type f -name '*.py[co]' `
 	rm -f `find . -type f -name '*~' `
@@ -80,4 +84,3 @@ clean:
 	rm -rf dist
 	python setup.py clean
 	rm -rf site
-	docker-compose down -v

--- a/pydantic_odm/db.py
+++ b/pydantic_odm/db.py
@@ -144,6 +144,8 @@ class MongoDBManager(metaclass=MongoDBManagerMeta):
                 'port': configuration.get('PORT'),
                 'authSource': configuration.get('AUTH_SOURCE', ''),
             }
+            if 'OPTIONAL_PARAMETERS' in configuration:
+                connection_params.update(**configuration['OPTIONAL_PARAMETERS'])
             auth_mech = configuration.get('AUTH_MECHANISM')
             if auth_mech:
                 connection_params['authMechanism'] = auth_mech

--- a/pydantic_odm/db.py
+++ b/pydantic_odm/db.py
@@ -144,7 +144,7 @@ class MongoDBManager(metaclass=MongoDBManagerMeta):
                 "port": configuration.get("PORT"),
                 "authSource": configuration.get("AUTH_SOURCE", ""),
             }
-            if 'OPTIONAL_PARAMETERS' in configuration:
+            if "OPTIONAL_PARAMETERS" in configuration:
                 connection_params.update(**configuration["OPTIONAL_PARAMETERS"])
             auth_mech = configuration.get("AUTH_MECHANISM")
             if auth_mech:

--- a/tests/db.py
+++ b/tests/db.py
@@ -94,6 +94,26 @@ class InitConnectionWithMongoDBManagerTestCase:
                 },
                 id='full',
             ),
+            pytest.param(
+                {
+                    'default': {
+                        'NAME': 'test_mongo',
+                        'PORT': 37017,
+                        'USERNAME': 'local',
+                        'PASSWORD': 'local_pass',
+                        'HOST': 'localhost',
+                        'AUTH_SOURCE': 'admin',
+                        'AUTH_MECHANISM': 'SCRAM-SHA-256',
+                        'OPTIONAL_PARAMETERS': {
+                            'socketTimeoutMS': 100,
+                            'connectTimeoutMS': 100,
+                            'serverSelectionTimeoutMS': 100,
+
+                        }
+                    }
+                },
+                id='with_optional_parameters',
+            ),
         ],
     )
     async def test_init_connections(self, event_loop, settings):

--- a/tests/db.py
+++ b/tests/db.py
@@ -108,8 +108,7 @@ class InitConnectionWithMongoDBManagerTestCase:
                             'socketTimeoutMS': 100,
                             'connectTimeoutMS': 100,
                             'serverSelectionTimeoutMS': 100,
-
-                        }
+                        },
                     }
                 },
                 id='with_optional_parameters',

--- a/tests/db.py
+++ b/tests/db.py
@@ -96,22 +96,22 @@ class InitConnectionWithMongoDBManagerTestCase:
             ),
             pytest.param(
                 {
-                    'default': {
-                        'NAME': 'test_mongo',
-                        'PORT': 37017,
-                        'USERNAME': 'local',
-                        'PASSWORD': 'local_pass',
-                        'HOST': 'localhost',
-                        'AUTH_SOURCE': 'admin',
-                        'AUTH_MECHANISM': 'SCRAM-SHA-256',
-                        'OPTIONAL_PARAMETERS': {
-                            'socketTimeoutMS': 100,
-                            'connectTimeoutMS': 100,
-                            'serverSelectionTimeoutMS': 100,
+                    "default": {
+                        "NAME": "test_mongo",
+                        "PORT": 37017,
+                        "USERNAME": "local",
+                        "PASSWORD": "local_pass",
+                        "HOST": "localhost",
+                        "AUTH_SOURCE": "admin",
+                        "AUTH_MECHANISM": "SCRAM-SHA-256",
+                        "OPTIONAL_PARAMETERS": {
+                            "socketTimeoutMS": 100,
+                            "connectTimeoutMS": 100,
+                            "serverSelectionTimeoutMS": 100,
                         },
                     }
                 },
-                id='with_optional_parameters',
+                id="with_optional_parameters",
             ),
         ],
     )


### PR DESCRIPTION
Hi all!

(Great project! I'm already using this in my project for about 6 weeks now!)

I needed a way to pass optional parameters to AsyncIOMotorClient. I believe the solution is not the most pretties now, because there is this one configuration dict per client that is going to be cut to pieces (there was already: `connection_params`, `authMechanism`, `io_loop` and `db_name`). Any ideas on this?

The way it is now it still contains a ~bug~feature: you can override keys like username, password, host, port, authSource. I think this should not be possible though, but did build that kind of validation right now. 