### PR TITLE
fix BaseMongoDBDecoder for documents with arrays of simple type

### DIFF
--- a/pydantic_odm/decoders/mongodb.py
+++ b/pydantic_odm/decoders/mongodb.py
@@ -34,7 +34,9 @@ class BaseMongoDBDecoder(AbstractMongoDBDecoder):
             if isinstance(v, list):
                 v_list = []
                 for item in v:
-                    v_list.append(self.__call__(item) if isinstance(item, dict) else item)
+                    if isinstance(item, dict):
+                        item = self.__call__(item)
+                    v_list.append(item)
                 decoded_data[k] = v_list
             elif isinstance(v, dict):
                 decoded_data[k] = self.__call__(v)

--- a/pydantic_odm/decoders/mongodb.py
+++ b/pydantic_odm/decoders/mongodb.py
@@ -34,7 +34,7 @@ class BaseMongoDBDecoder(AbstractMongoDBDecoder):
             if isinstance(v, list):
                 v_list = []
                 for item in v:
-                    v_list.append(self.__call__(item))
+                    v_list.append(self.__call__(item) if isinstance(item, dict) else item)
                 decoded_data[k] = v_list
             elif isinstance(v, dict):
                 decoded_data[k] = self.__call__(v)

--- a/tests/decoders/mongodb.py
+++ b/tests/decoders/mongodb.py
@@ -79,6 +79,21 @@ class BaseMongoDBDecoderTestCase:
                 },
                 id='nested',
             ),
+            pytest.param(
+                {
+                    '_id': bson.ObjectId('1f19e462fa9c1eab66db23fb'),
+                    'username': 'test',
+                    'full_name': 'Test Object',
+                    'nested': ['A', 'B', 'C']
+                },
+                {
+                    'id': bson.ObjectId('1f19e462fa9c1eab66db23fb'),
+                    'username': 'test',
+                    'full_name': 'Test Object',
+                    'nested': ['A', 'B', 'C']
+                },
+                id='nested simple types',
+            ),
         ],
     )
     async def test_decode_mongodb_document(self, data, expected):

--- a/tests/decoders/mongodb.py
+++ b/tests/decoders/mongodb.py
@@ -81,18 +81,18 @@ class BaseMongoDBDecoderTestCase:
             ),
             pytest.param(
                 {
-                    '_id': bson.ObjectId('1f19e462fa9c1eab66db23fb'),
-                    'username': 'test',
-                    'full_name': 'Test Object',
-                    'nested': ['A', 'B', 'C']
+                    "_id": bson.ObjectId("1f19e462fa9c1eab66db23fb"),
+                    "username": "test",
+                    "full_name": "Test Object",
+                    "nested": ["A", "B", "C"],
                 },
                 {
-                    'id': bson.ObjectId('1f19e462fa9c1eab66db23fb'),
-                    'username': 'test',
-                    'full_name': 'Test Object',
-                    'nested': ['A', 'B', 'C']
+                    "id": bson.ObjectId("1f19e462fa9c1eab66db23fb"),
+                    "username": "test",
+                    "full_name": "Test Object",
+                    "nested": ["A", "B", "C"],
                 },
-                id='nested simple types',
+                id="nested simple types",
             ),
         ],
     )


### PR DESCRIPTION
BaseMongoDBDecoder raise AttributeError: 'str' object has no attribute 'copy' when run on mongo document with array of string