### PR TITLE
Add encoder: Decimal to Decimal128

### DIFF
--- a/pydantic_odm/encoders/mongodb.py
+++ b/pydantic_odm/encoders/mongodb.py
@@ -86,4 +86,5 @@ class BaseMongoDBEncoder(AbstractMongoDBEncoder):
 
     def __call__(self, data: "DictStrAny") -> "DictStrAny":
         data = cast("DictStrAny", _convert_enums(data))
+        data = cast("DictStrAny", _convert_decimals(data))
         return data

--- a/pydantic_odm/encoders/mongodb.py
+++ b/pydantic_odm/encoders/mongodb.py
@@ -2,10 +2,10 @@
 from __future__ import annotations
 
 import abc
+from bson.decimal128 import Decimal128
+from decimal import Decimal
 from enum import Enum
 from typing import TYPE_CHECKING, Any, Callable, List, Union, cast
-from decimal import Decimal
-from bson.decimal128 import Decimal128
 
 if TYPE_CHECKING:
     from pydantic.typing import DictStrAny

--- a/pydantic_odm/encoders/mongodb.py
+++ b/pydantic_odm/encoders/mongodb.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 import abc
 from enum import Enum
 from typing import TYPE_CHECKING, Any, Callable, List, Union, cast
+from decimal import Decimal
+from bson.decimal128 import Decimal128
 
 if TYPE_CHECKING:
     from pydantic.typing import DictStrAny
@@ -13,19 +15,14 @@ class AbstractMongoDBEncoder(abc.ABC):
     """Abstract MongoDB encoder"""
 
     @abc.abstractmethod
-    def __call__(self, data: 'DictStrAny') -> 'DictStrAny':
+    def __call__(self, data: "DictStrAny") -> "DictStrAny":
         """Convert data from pydantic model or dict to dict supported MongoDB"""
         raise NotImplementedError()
 
 
-def _convert_enums(
-    data: Union['DictStrAny', List[Any]]
-) -> Union['DictStrAny', List[Any]]:
-    """
-    Convert Enum to Enum.value for mongo query
-
-    Note: May be this solution not good
-    """
+def _recursive_iterator(
+    data: Union["DictStrAny", List[Any]], transform_func
+) -> Union["DictStrAny", List[Any]]:
     # Cast append func type
     append: Callable[[Union[str, int], Any], None]
     # Convert in list
@@ -35,27 +32,58 @@ def _convert_enums(
     append = lambda k, v: _data.append(v)  # noqa: E731
     # Convert in dict
     if isinstance(data, dict):
-        data = cast('DictStrAny', data)
+        data = cast("DictStrAny", data)
         iterator = data.items()
         _data = {}
         append = lambda k, v: _data.update({k: v})  # noqa: E731
     # Iterate passed data
     for key, value in iterator:
         # Replace enum object to enum value
-        if isinstance(value, Enum):
-            value = value.value
+        value = transform_func(value)
         # Recursive call if find sequence
         if isinstance(value, (list, dict)):
-            value = _convert_enums(value)
+            value = _recursive_iterator(value, transform_func)
         # Update new data with update method (append for list and update for dict)
         append(key, value)
     # Return new data
     return _data
 
 
+def _convert_enums(
+    data: Union["DictStrAny", List[Any]]
+) -> Union["DictStrAny", List[Any]]:
+    """
+    Convert Enum to Enum.value for mongo query
+
+    Note: May be this solution not good
+    """
+
+    def transform(value):
+        if isinstance(value, Enum):
+            value = value.value
+        return value
+
+    return _recursive_iterator(data, transform)
+
+
+def _convert_decimals(
+    data: Union["DictStrAny", List[Any]]
+) -> Union["DictStrAny", List[Any]]:
+    """
+    Convert decimal.Decimal to bson.decimal128.Decimal128
+    """
+
+    def transform(value):
+        if isinstance(value, Decimal):
+            value = Decimal128(value)
+        return value
+
+    return _recursive_iterator(data, transform)
+
+
 class BaseMongoDBEncoder(AbstractMongoDBEncoder):
     """Base MongoDB encoder"""
 
-    def __call__(self, data: 'DictStrAny') -> 'DictStrAny':
-        data = cast('DictStrAny', _convert_enums(data))
+    def __call__(self, data: "DictStrAny") -> "DictStrAny":
+        data = cast("DictStrAny", _convert_enums(data))
         return data

--- a/tests/encoders/mongodb.py
+++ b/tests/encoders/mongodb.py
@@ -92,23 +92,23 @@ class EncodeDecimalsTestCase:
                 id="simple_dict",
             ),
             pytest.param(
-                [{"money_amount": Decimal("13.37")},],
-                [{"money_amount": Decimal128("13.37")},],
+                [{"money_amount": Decimal("13.37")}],
+                [{"money_amount": Decimal128("13.37")}],
                 id="simple_list",
             ),
             pytest.param(
-                {"author": {"money_amount": Decimal("13.37")},},
-                {"author": {"money_amount": Decimal128("13.37")},},
+                {"author": {"money_amount": Decimal("13.37")}},
+                {"author": {"money_amount": Decimal128("13.37")}},
                 id="nested",
             ),
             pytest.param(
                 {
                     "title": "test",
-                    "contributors": [{"money_amount": Decimal("13.37")},],
+                    "contributors": [{"money_amount": Decimal("13.37")}],
                 },
                 {
                     "title": "test",
-                    "contributors": [{"money_amount": Decimal128("13.37")},],
+                    "contributors": [{"money_amount": Decimal128("13.37")}],
                 },
                 id="list_in_nested",
             ),

--- a/tests/encoders/mongodb.py
+++ b/tests/encoders/mongodb.py
@@ -1,10 +1,10 @@
 """Tests for mongodb encoders"""
 import pytest
-from bson.decimal128 import Decimal128
-from decimal import Decimal
 from enum import Enum
 
 from pydantic_odm.encoders import mongodb as mongodb_encoders
+from decimal import Decimal
+from bson.decimal128 import Decimal128
 
 pytestmark = pytest.mark.asyncio
 
@@ -80,6 +80,42 @@ class EncodeEnumTestCase:
     )
     async def test__convert_enums(self, data, expected):
         assert mongodb_encoders._convert_enums(data) == expected
+
+
+class EncodeDecimalsTestCase:
+    @pytest.mark.parametrize(
+        "data, expected",
+        [
+            pytest.param(
+                {"money_amount": Decimal("13.37")},
+                {"money_amount": Decimal128("13.37")},
+                id="simple_dict",
+            ),
+            pytest.param(
+                [{"money_amount": Decimal("13.37")},],
+                [{"money_amount": Decimal128("13.37")},],
+                id="simple_list",
+            ),
+            pytest.param(
+                {"author": {"money_amount": Decimal("13.37")},},
+                {"author": {"money_amount": Decimal128("13.37")},},
+                id="nested",
+            ),
+            pytest.param(
+                {
+                    "title": "test",
+                    "contributors": [{"money_amount": Decimal("13.37")},],
+                },
+                {
+                    "title": "test",
+                    "contributors": [{"money_amount": Decimal128("13.37")},],
+                },
+                id="list_in_nested",
+            ),
+        ],
+    )
+    async def test__convert_decimals(self, data, expected):
+        assert mongodb_encoders._convert_decimals(data) == expected
 
 
 class BaseMongoDBEncoderTestCase:

--- a/tests/encoders/mongodb.py
+++ b/tests/encoders/mongodb.py
@@ -1,10 +1,10 @@
 """Tests for mongodb encoders"""
 import pytest
+from bson.decimal128 import Decimal128
+from decimal import Decimal
 from enum import Enum
 
 from pydantic_odm.encoders import mongodb as mongodb_encoders
-from decimal import Decimal
-from bson.decimal128 import Decimal128
 
 pytestmark = pytest.mark.asyncio
 

--- a/tests/encoders/mongodb.py
+++ b/tests/encoders/mongodb.py
@@ -3,6 +3,8 @@ import pytest
 from enum import Enum
 
 from pydantic_odm.encoders import mongodb as mongodb_encoders
+from decimal import Decimal
+from bson.decimal128 import Decimal128
 
 pytestmark = pytest.mark.asyncio
 


### PR DESCRIPTION
Add an encoder to encode `decimal.Decimal` instances into `from bson.decimal128.Decimal128`.
Mongo stores this as NumberDecimal:
![image](https://user-images.githubusercontent.com/2786295/94937592-11023c80-04d0-11eb-98db-6feb9c3e6d74.png)
