### PR TITLE
Bugfix: serializing to json on a BaseDBMixin with child DBPydanticMixin's fails

### DIFF
--- a/pydantic_odm/mixins.py
+++ b/pydantic_odm/mixins.py
@@ -110,7 +110,7 @@ class BaseDBMixin(BaseModel, abc.ABC):
 class DBPydanticMixin(BaseDBMixin):
     """Help class for communicate of Pydantic model and MongoDB"""
 
-    class Config(BaseDBMixin.Config):
+    class Config:
         # DB
         collection: Optional[str] = None
         database: Optional[str] = None

--- a/pydantic_odm/mixins.py
+++ b/pydantic_odm/mixins.py
@@ -32,6 +32,7 @@ class BaseDBMixin(BaseModel, abc.ABC):
 
     class Config:
         allow_population_by_field_name = True
+        json_encoders: "DictAny" = {ObjectId: lambda v: ObjectIdStr(v)}
 
     def __setattr__(self, key: Any, value: Any) -> Any:
         if key not in ["_doc"]:
@@ -109,11 +110,10 @@ class BaseDBMixin(BaseModel, abc.ABC):
 class DBPydanticMixin(BaseDBMixin):
     """Help class for communicate of Pydantic model and MongoDB"""
 
-    class Config:
+    class Config(BaseDBMixin.Config):
         # DB
         collection: Optional[str] = None
         database: Optional[str] = None
-        json_encoders: "DictAny" = {ObjectId: lambda v: ObjectIdStr(v)}
 
     @classmethod
     async def get_collection(cls) -> Collection:

--- a/tests/mixins.py
+++ b/tests/mixins.py
@@ -515,6 +515,8 @@ class DBPydanticMixinTestCase:
         """
 
         class FooThing(mixins.DBPydanticMixin):
+            """Model specific to this test"""
+
             name: str
 
             class Config:
@@ -522,6 +524,8 @@ class DBPydanticMixinTestCase:
                 collection = "test_post"
 
         class SomeContainer(mixins.BaseDBMixin):
+            """Container BaseDBMixin specific to this test"""
+
             many_things: List[FooThing]
 
         container = SomeContainer(
@@ -535,11 +539,19 @@ class DBPydanticMixinTestCase:
         container_2 = SomeContainer(many_things=container.many_things)
         container_2.json()
 
-    async def test_basedbmixin_can_be_serialized_to_json_when_child_has_objectid(self,):
+    async def test_basedbmixin_can_be_serialized_to_json_when_child_has_objectid(self):
+        """Another more simple testcase that tests if a BaseDBMixin can be serialized
+        to json when a child has an ObjectId. This does not require a live database.
+        """
+
         class BarThing(mixins.DBPydanticMixin):
+            """Model specific to this test"""
+
             name: str
 
         class AnotherContainer(mixins.BaseDBMixin):
+            """Container BaseDBMixin specific to this test"""
+
             many_things: List[BarThing]
 
         bar = BarThing(name="haha")

--- a/tests/mixins.py
+++ b/tests/mixins.py
@@ -506,10 +506,9 @@ class DBPydanticMixinTestCase:
         with pytest.raises(ValueError, match=raise_msg):
             await user.reload()
 
-    async def test_bug_serialize_to_json_when_model_is_deeply_nested(
-        self, init_test_db
-    ):
-        """When you have a BaseDBMixin container model with children that are
+    async def test_serialize_to_json_when_model_is_deeply_nested(self, init_test_db):
+        """
+        When you have a BaseDBMixin container model with children that are
         DBPydanticMixin, serializing to json fails after the child objects are saved.
         (eg. then now have an ObjectId)
         """
@@ -540,7 +539,8 @@ class DBPydanticMixinTestCase:
         container_2.json()
 
     async def test_basedbmixin_can_be_serialized_to_json_when_child_has_objectid(self):
-        """Another more simple testcase that tests if a BaseDBMixin can be serialized
+        """
+        Another more simple testcase that tests if a BaseDBMixin can be serialized
         to json when a child has an ObjectId. This does not require a live database.
         """
 

--- a/tests/mixins.py
+++ b/tests/mixins.py
@@ -506,12 +506,14 @@ class DBPydanticMixinTestCase:
         with pytest.raises(ValueError, match=raise_msg):
             await user.reload()
 
-    async def test_bug_serialize_to_json_when_model_is_deeply_nested(self, init_test_db):
-        """Failing testcase:
-        When you have a BaseDBMixin container model with children that are
+    async def test_bug_serialize_to_json_when_model_is_deeply_nested(
+        self, init_test_db
+    ):
+        """When you have a BaseDBMixin container model with children that are
         DBPydanticMixin, serializing to json fails after the child objects are saved.
         (eg. then now have an ObjectId)
         """
+
         class FooThing(mixins.DBPydanticMixin):
             name: str
 
@@ -532,3 +534,15 @@ class DBPydanticMixinTestCase:
 
         container_2 = SomeContainer(many_things=container.many_things)
         container_2.json()
+
+    async def test_basedbmixin_can_be_serialized_to_json_when_child_has_objectid(self,):
+        class BarThing(mixins.DBPydanticMixin):
+            name: str
+
+        class AnotherContainer(mixins.BaseDBMixin):
+            many_things: List[BarThing]
+
+        bar = BarThing(name="haha")
+        bar.id = ObjectId()  # you would never set an id. having this is another issue
+        container = AnotherContainer(many_things=[bar])
+        container.json()


### PR DESCRIPTION
Fixed a a bug where if you have a container of type BaseDBMixin which has children of type DBPydanticMixin that has ObjectId (the child objects are saved) it could not serialize to json.

This fixes a `TypeError: Object of type 'ObjectId' is not JSON serializable`