### PR TITLE
Fix wrong coverage reports from codecov

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ down-services:
 
 .PHONY: test
 test: up-services
-	pytest --cov=pydantic_odm --cov-config=setup.cfg --no-cov-on-fail
+	pytest --cov-config=setup.cfg --cov-report=term --assert=plain --no-cov-on-fail --cov=pydantic_odm tests/
 
 .PHONY: testwatch
 testwatch: up-services
@@ -57,15 +57,17 @@ testwatch: up-services
 .PHONY: testcov
 testcov: test
 	echo "run tests and building coverage html report"
-	@coverage html
+	@coverage html --rcfile=setup.cfg
+	@coverage xml --rcfile=setup.cfg
 
 .PHONY: testcov-report
 testcov-report:
 	echo "building coverage html report"
-	@coverage html -i
+	@coverage html -i --rcfile=setup.cfg
+	@coverage xml -i --rcfile=setup.cfg
 
 .PHONY: all
-all: testcov lint
+all: test lint
 
 .PHONY: clean
 clean: down-services
@@ -80,6 +82,7 @@ clean: down-services
 	rm -rf *.egg-info
 	rm -f .coverage
 	rm -f .coverage.*
+	rm -f coverage.*
 	rm -rf build
 	rm -rf dist
 	python setup.py clean

--- a/setup.cfg
+++ b/setup.cfg
@@ -40,6 +40,7 @@ branch = True
 [coverage:report]
 precision = 2
 fail_under = 85
+show_missing = True
 exclude_lines =
     pragma: no cover
     raise NotImplementedError


### PR DESCRIPTION
Codecov generate [wrong coverage reports](https://codecov.io/gh/i8enn/pydantic-odm/commit/af1cbc77e75a1c31ae737dcdecca20ed268376e3/graphs) with 100% test coverage in latest time (in fact, there about 90%). This PR trying fix this error.